### PR TITLE
Fix of Admin Dashboard Analytics counters

### DIFF
--- a/FrontEnd/src/Pages/ControlPanel/ControlPanel.jsx
+++ b/FrontEnd/src/Pages/ControlPanel/ControlPanel.jsx
@@ -9,6 +9,9 @@ import {
   compararFecha, contarAlumnos, contarClases, contarProfes,
 } from '../../utils/utilFunctions';
 import { host } from '../../utils/requestUtils';
+import { getClasses } from '../../api/classes';
+import { getPeriodos as gp } from '../../api/Periodos';
+import { getClassStudent } from '../../api/classStudent';
 
 // Possible function to get users, this goes in another file
 
@@ -16,7 +19,10 @@ let cursosRegistrados = 0;
 let profesInscritos = 0;
 let alumnosInscritos = 0;
 
-let periodoActual = 'No se encontraron Periodos';
+let periodoActual = {
+  id: '1',
+  clave: 'No se encontraron Periodos',
+};
 
 function ControlPanel({ changeContent }) {
   const [dataAlumno, setDataAlumno] = useState([]);
@@ -49,27 +55,34 @@ function ControlPanel({ changeContent }) {
 
   // ----------------------Obtencion de datos de la base de datos
   const getPeriodos = async () => {
-    const res = await axios.get(host+'/v1/periodos' );
-    setData(res.data);
+    const res = await gp();
+    const response = await res.json();
+    setData(response);
     // console.log('Fetch Periodos', res.data)
-    periodoActual = compararFecha(res.data);
+    periodoActual = compararFecha(response);
   };
 
   const getClase = async () => {
-    const res = await axios.get(host+'/v1/clases');
-    setDataClase(res.data);
+    const res = await getClasses();
+    const response = await res.json();
+    setDataClase(response);
     // funciones para encontrar stats
     // console.log('Fetch Clase', res.data)
     // console.log('Cursos Registrados: ',contarClases(res.data))
-    cursosRegistrados = contarClases(res.data);
+    cursosRegistrados = contarClases(response, periodoActual.clave);
     // console.log('Profesores Inscritos', contarProfes(res.data))
-    profesInscritos = contarProfes(res.data);
+    profesInscritos = contarProfes(response, periodoActual.clave);
+  };
+  
+  const getAlumno = async () => {
+    const res = await getClassStudent();
+    const response = await res.json();
     // console.log('Alumnos Inscritos: ', contarAlumnos(res.data))
-    alumnosInscritos = contarAlumnos(res.data);
+    alumnosInscritos = contarAlumnos(response, periodoActual.id);
   };
 
   useEffect(() => {
-    // getAlumno();
+    getAlumno();
     // getProfesor();
     getClase();
     getPeriodos();
@@ -88,7 +101,7 @@ function ControlPanel({ changeContent }) {
           fontFamily: 'default', fontSize: 'h5.fontSize', py: 2, display: 'flex', justifyContent: 'space-between', textAlign: 'right', float: 'right', marginRight: 0.5,
         }}
         >
-          {periodoActual}
+          {periodoActual.clave}
         </Box>
         <Grid container spacing={1.5}>
           {panelInfoCards.map((infoCard) => (

--- a/FrontEnd/src/utils/utilFunctions.js
+++ b/FrontEnd/src/utils/utilFunctions.js
@@ -28,19 +28,20 @@ export const compararFecha = (data) => {
     const valorD = Number(separado[2]) / 10000;
     const valorT = valorA + valorM + valorD;
     const obj = {
-      id: element.clave,
+      id: element._id,
+      clave: element.clave,
       fecha: valorT,
     };
     periodos.push(obj);
   }
 
   periodos.sort((a, b) => b.fecha - a.fecha);
-  const clave = String(periodos[0].id);
-  return (clave);
+  // const clave = String(periodos[0].id);
+  return periodos[0];
 }
 
 // -------------------Funcion para contar cursos en periodo actual
-export const contarClases = (datos) => {
+export const contarClases = (datos, periodoActual) => {
   console.log('Este es la data inicial', datos);
   let contadorClases = 0;
 
@@ -56,7 +57,7 @@ export const contarClases = (datos) => {
 }
 
 // ---------------------------Funcion para contar profesores actuales
-export const contarProfes = (datos) => {
+export const contarProfes = (datos, periodoActual) => {
   const listaProfes = [];
   datos.forEach((element) => {
     if (element.clavePeriodo === periodoActual) {
@@ -72,14 +73,9 @@ export const contarProfes = (datos) => {
 }
 
 // -------------------- Function para contar alumnos
-export const contarAlumnos = (datos) => {
-  let alumnos = 0;
-  datos.forEach((element) => {
-    if (element.clavePeriodo === periodoActual) {
-      alumnos += Number(element.cupo_actual);
-    }
-  });
-  return (alumnos);
+export const contarAlumnos = (datos, periodoActual) => {
+  const students = datos.filter((element) => element.idPeriodo === periodoActual);
+  return students.length;
 }
 
 // funciones para sacar asociar datos a periodos


### PR DESCRIPTION
This PR fixes the admin counters C:

- Removed Axios Requests
- Implemented Fetch API Requests
- Fixed `contarAlumnos`, `contarProfes`, `contarClases` functions
- Switched the `compararFecha` function behavior to return more data of current period.